### PR TITLE
[Feat] Add ability to checkout individual products directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rye-api/rye-pay",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "This package contains the Rye payment client required to perform checkout using Rye Cart-API",
   "repository": {
     "type": "git",

--- a/src/applePay.ts
+++ b/src/applePay.ts
@@ -43,6 +43,7 @@ export class ApplePay {
   private cartCurrency: string = 'USD';
   private cartHasMultipleStores: boolean = false;
   private cartShippingMethods: ShippingMethod[] = [];
+  private cartId: string = '';
 
   constructor({ cartApiEndpoint, applePayInputParams, onCartSubmitted, log }: ApplePayParams) {
     this.cartApiEndpoint = cartApiEndpoint;
@@ -55,37 +56,50 @@ export class ApplePay {
   /**
    * Load Apple Pay and fetch the cart subtotal and currency
    */
+
   loadApplePay = async () => {
-    // Fetch cart subtotal and currency to create the ApplePay PaymentRequest body
+    const { cartId, variantId, shopperIp } = this.applePayInputParams;
+
+    if (!cartId && !variantId) {
+      this.log('Cart ID or Variant ID must be provided');
+      return;
+    }
+
     try {
-      const getCartResponse = await this.cartService.getCart(
-        this.applePayInputParams.cartId,
-        this.applePayInputParams.shopperIp
-      );
+      const cartResponse = cartId
+        ? await this.cartService.getCart(cartId, shopperIp)
+        : await this.cartService.createCart(variantId!, shopperIp);
 
-      this.cartSubtotal = Number(getCartResponse.cart.cost.subtotal.value) / 100;
-      this.cartCurrency = getCartResponse.cart.cost.subtotal.currency;
-      this.cartHasMultipleStores = getCartResponse.cart.stores.length > 1;
+      this.cartSubtotal = Number(cartResponse.cart.cost.subtotal.value) / 100;
+      this.cartCurrency = cartResponse.cart.cost.subtotal.currency;
+
+      this.cartHasMultipleStores = cartResponse.cart.stores.length > 1;
+      this.cartId = cartId ?? cartResponse.cart.id;
+
+      console.log(this.cartCurrency);
       const storeWithoutShippingMethod =
-        getCartResponse.cart.stores.find(
-          (store: RyeStore) => !store.offer.selectedShippingMethod
-        ) ?? null;
-
+        cartResponse.cart.stores.find((store: RyeStore) => !store.offer.selectedShippingMethod) ??
+        null;
+      
+      // Cart has multiple stores and at least one store does not have a shipping method selected
       if (this.cartHasMultipleStores && storeWithoutShippingMethod) {
         this.log(
           'Shipping methods need to be selected for all stores in cart to display Apple Pay button.'
         );
       } else {
-        // Show the Apple Pay button
-        const applePayScript = document.createElement('script');
-        applePayScript.src = APPLE_PAY_SCRIPT_URL;
-        document.head.appendChild(applePayScript);
-        applePayScript.onload = () => {
-          this.initializeApplePay();
-        };
+        this.loadApplePayScript();
       }
     } catch (error) {
-      this.log(`Error fetching cart cost: ${error}`);
+      this.log(`Error ${cartId ? 'fetching' : 'creating'} cart: ${error}`);
+    }
+  };
+
+  loadApplePayScript = () => {
+    const applePayScript = document.createElement('script');
+    applePayScript.src = APPLE_PAY_SCRIPT_URL;
+    document.head.appendChild(applePayScript);
+    applePayScript.onload = () => {
+      this.initializeApplePay();
     }
   };
 
@@ -273,7 +287,7 @@ export class ApplePay {
     // If cart has multiple stores, all shipping options must have already been selected, no reason to update buyer identity again.
     if (!this.cartHasMultipleStores) {
       const updateBuyerIdentityResponse = await this.cartService.updateBuyerIdentity(
-        this.applePayInputParams.cartId,
+        this.cartId,
         this.applePayInputParams.shopperIp,
         event.payment.shippingContact!
       );
@@ -307,7 +321,7 @@ export class ApplePay {
       zip: address?.postalCode ?? '',
       country: address?.countryCode ?? '',
       metadata: {
-        cartId: this.applePayInputParams.cartId,
+        cartId: this.cartId,
         selectedShippingOptions: JSON.stringify(
           this.cartHasMultipleStores ? this.cartShippingMethods : selectedShippingOptions
         ),
@@ -337,7 +351,7 @@ export class ApplePay {
    */
   private getAppleShippingOptions = async (shippingAddress: ApplePayJS.ApplePayPaymentContact) => {
     const content = await this.cartService.updateBuyerIdentity(
-      this.applePayInputParams.cartId,
+      this.cartId,
       this.applePayInputParams.shopperIp,
       shippingAddress
     );

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
-export const APPLE_PAY_MERCHANT_IDENTIFIER = 'merchant.app.ngrok.14e94dd56b77'; // TODO: change it to a production identifier
+export const APPLE_PAY_MERCHANT_IDENTIFIER = 'merchant.com.rye';
 export const APPLE_PAY_SERVER_URL = 'https://apple-pay-server-ggymj6kjkq-uc.a.run.app';
 export const APPLE_PAY_SCRIPT_URL = 'https://applepay.cdn-apple.com/jsapi/v1.1.0/apple-pay-sdk.js';
 export const APPLE_PAY_VERSION = 3;

--- a/src/googlePay.ts
+++ b/src/googlePay.ts
@@ -241,7 +241,10 @@ export class GooglePay {
         },
       };
 
-      const result = await this.cartService.submitCart({ token: paymentToken, paymentDetails });
+      const result = await this.cartService.submitCart({
+        googlePayToken: JSON.parse(paymentToken),
+        paymentDetails,
+      });
       this.onCartSubmitted?.(result.submitCart, result.errors);
     } catch (error) {
       // Handle any errors that occur during the payment process

--- a/src/rye-pay.ts
+++ b/src/rye-pay.ts
@@ -104,7 +104,8 @@ export interface InitParams extends SpreedlyInitParams {
 }
 
 export interface ApplePayInputParams {
-  cartId: string;
+  cartId?: string;
+  variantId?: string;
   shopperIp: string;
   merchantDisplayName: string; // The merchant display name that appears on the Apple Pay sheet.
   merchantDomain: string; // The domain on which the Apple Pay button will appear on.
@@ -155,6 +156,7 @@ export interface CartApiSubmitInput {
   id: string;
   token: string;
   applePayToken?: ApplePayToken;
+  googlePayPaymentTokenInput?: GooglePayToken;
   billingAddress: BillingAddress;
   selectedShippingOptions?: SelectedShippingOption[];
   experimentalPromoCodes?: StorePromoCodes[];
@@ -164,6 +166,13 @@ export interface SubmitCartParams {
   token?: string;
   paymentDetails: SpreedlyAdditionalFields;
   applePayToken?: ApplePayToken;
+  googlePayToken?: GooglePayToken;
+}
+
+interface GooglePayToken {
+  signature: string;
+  protocolVersion: string;
+  signedMessage: string;
 }
 
 interface ApplePayToken {
@@ -304,7 +313,7 @@ const prodCartApiEndpoint =
   process.env.CART_API_PRODUCTION_URL ?? 'https://graphql.api.rye.com/v1/query';
 const stageCartApiEndpoint =
   process.env.CART_API_STAGING_URL ?? 'https://staging.beta.graphql.api.rye.com/v1/query';
-const localCartApiEndpoint = 'http://localhost:3000/v1/query';
+const localCartApiEndpoint = 'https://c5f288b265d5.ngrok.app/v1/query';
 export const ryeShopperIpHeaderKey = 'x-rye-shopper-ip';
 
 export const cartSubmitResponse = `


### PR DESCRIPTION
## Summary

The Apple pay button can be displayed on the product page directly now. 

RyePay can be initialized in the following way:

```
applePayInputParams: {
  shopperIp: '<SHOPPER_IP>',
  variantId: '47405773390109',
  merchantDisplayName: 'Rye',
  merchantDomain: '<MERCHANT_DOMAIN>'
},
```

Once the button is clicked, a cart is directly created which will be ready for checkout.